### PR TITLE
feat: use NodeEventHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,15 @@
 'use strict';
+
+// setup uncaught exception handling
+try {
+    const NodeEventHandler = require('@teamhive/node-event-handler').NodeEventHandler;
+
+    NodeEventHandler.logUncaughtException();
+    NodeEventHandler.logUnhandleRejection();
+} catch (error) {
+    console.error('ERROR SETTING UP EVENT HANDLER: ' + error);
+    process.exit(1);
+}
+
+// start application
 require('./dist/index.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,24 @@
                 "js-tokens": "^4.0.0"
             }
         },
-        "@teamhive/typedi-common": {
+        "@teamhive/node-event-handler": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@teamhive/typedi-common/-/typedi-common-1.0.0.tgz",
-            "integrity": "sha512-Nq80QMLsnd7OzEUEttn+8n+1FRe6hcktGFFmAIAqwu+7wNlq8jAnwO8urAQs/lmIfrYVXxRBdJSXjAp3S6T83g==",
+            "resolved": "https://registry.npmjs.org/@teamhive/node-event-handler/-/node-event-handler-1.0.0.tgz",
+            "integrity": "sha512-UNxRd3Utgs9eqKWof+A84Ux0+x3HNabu+xKnRhXbAUkxD3AWBQRs38ABq7xxxGiL7QY/DDy6sBTM5Km3QpmYmA=="
+        },
+        "@teamhive/typedi-common": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@teamhive/typedi-common/-/typedi-common-2.0.0.tgz",
+            "integrity": "sha512-leLRPD+rG6MP4z0ytprlixKd0WoCavqcNI3AsAyYpgn58S2MysEWJ7ZUXf5wbRrFf/1aR2HgN+Z19lkN22+2Ng==",
             "requires": {
-                "bluebird": "^3.5.3"
+                "bluebird": "^3.5.5"
+            },
+            "dependencies": {
+                "bluebird": {
+                    "version": "3.5.5",
+                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+                    "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+                }
             }
         },
         "@types/config": {
@@ -240,7 +252,8 @@
         "bluebird": {
             "version": "3.5.3",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+            "dev": true
         },
         "boxen": {
             "version": "1.3.0",
@@ -470,7 +483,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -491,12 +505,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -511,17 +527,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -638,7 +657,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -650,6 +670,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -664,6 +685,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -671,12 +693,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -695,6 +719,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -775,7 +800,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -787,6 +813,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -872,7 +899,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -908,6 +936,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -927,6 +956,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -970,12 +1000,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
@@ -2557,7 +2589,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -2578,12 +2611,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -2598,17 +2633,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -2725,7 +2763,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -2737,6 +2776,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -2751,6 +2791,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -2758,12 +2799,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -2782,6 +2825,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -2862,7 +2906,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -2874,6 +2919,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -2959,7 +3005,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -2995,6 +3042,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -3014,6 +3062,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -3057,12 +3106,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     },
     "homepage": "https://github.com/TeamHive/typedi-seed#readme",
     "dependencies": {
-        "@teamhive/typedi-common": "1.0.0",
+        "@teamhive/node-event-handler": "^1.0.0",
+        "@teamhive/typedi-common": "^2.0.0",
         "config": "^3.1.0",
         "log4js": "^4.3.2",
         "raven": "^2.6.4",

--- a/src/modules/app.service.ts
+++ b/src/modules/app.service.ts
@@ -1,3 +1,4 @@
+import NodeEventHandler from '@teamhive/node-event-handler';
 import { ErrorHandler } from '@teamhive/typedi-common';
 import { Service } from 'typedi';
 
@@ -5,10 +6,14 @@ import { Service } from 'typedi';
 export class AppService {
     constructor(
         private readonly errorHandler: ErrorHandler
-    ) {}
+    ) { }
 
     async run() {
         try {
+            // handle uncaught exceptions
+            NodeEventHandler.handleUnhandledRejection(this.errorHandler);
+            NodeEventHandler.handleUncaughtException(this.errorHandler);
+
             const startTime = Date.now();
             this.errorHandler.captureBreadcrumb({ message: 'Running TypeDi Seed...' });
 


### PR DESCRIPTION
#### Short description of what this resolves:
Adds NodeEventHandler and removes internal EventHandler for EventHandler from typedi-common.

### PR Checklist
- [x] All `TODO`'s are done and removed
- [x] All `console.log`'s are removed
- [x] No secure information in committed yaml files
- [x] `package.json` has correct information and dependencies
- [x] Documented any complicated or confusing code
- [x] No linter errors
- [x] Project runs successfully (`npm start`)


#### Changes proposed in this pull request:
- Updates typedi-common to 2.0.0
- Registers NodeEventHandler from @teamhive/node-event-handler

**[JIRA Task Link](https://maestro.atlassian.net/browse/HIVE-15?atlOrigin=eyJpIjoiYmEzMGI5MGRlOTUyNGJiNTlkZTA1YjQ1MzM1MjQ1MWQiLCJwIjoiaiJ9)**